### PR TITLE
Include stdbool.h so that 'bool' is defined

### DIFF
--- a/ltp/fsx.c
+++ b/ltp/fsx.c
@@ -30,6 +30,7 @@
 #include <string.h>
 #include <stdarg.h>
 #include <errno.h>
+#include <stdbool.h>
 #ifdef AIO
 #include <libaio.h>
 #endif


### PR DESCRIPTION
As explained in the following link, ltp/fsx.c will not compile
unless stdbool is included.  The fix here mirrors the pending
upstream fix.

http://permalink.gmane.org/gmane.comp.file-systems.fstests/1665
