### PR TITLE
Add VSM config/fs options

### DIFF
--- a/common/config
+++ b/common/config
@@ -248,6 +248,7 @@ case "$HOSTOS" in
         export MKFS_CIFS_PROG="false"
         export MKFS_OVERLAY_PROG="false"
         export MKFS_REISER4_PROG="`set_prog_path mkfs.reiser4`"
+        export MKFS_SAMFS_PROG="`set_prog_path mkfs.vsm`"
         ;;
 esac
 
@@ -491,13 +492,15 @@ get_next_config() {
 		exit 1
 	fi
 
-	echo $TEST_DEV | grep -qE ":|//" > /dev/null 2>&1
-	if [ ! -b "$TEST_DEV" -a "$?" != "0" -a "$FSTYP" != "overlay" ]; then
-		echo "common/config: Error: \$TEST_DEV ($TEST_DEV) is not a block device or a network filesystem"
-		exit 1
-	elif [ "$FSTYP" == "overlay" -a ! -d "$TEST_DEV" ]; then
-		echo "common/config: Error: \$TEST_DEV ($TEST_DEV) is not a directory for overlay"
-		exit 1
+	if [ "$FSTYP" != "samfs" ]; then
+	    echo $TEST_DEV | grep -qE ":|//" > /dev/null 2>&1
+	    if [ ! -b "$TEST_DEV" -a "$?" != "0" -a "$FSTYP" != "overlay" ]; then
+		    echo "common/config: Error: \$TEST_DEV ($TEST_DEV) is not a block device or a network filesystem"
+			exit 1
+	    elif [ "$FSTYP" == "overlay" -a ! -d "$TEST_DEV" ]; then
+			echo "common/config: Error: \$TEST_DEV ($TEST_DEV) is not a directory for overlay"
+			exit 1
+	    fi
 	fi
 
 	if [ ! -d "$TEST_DIR" ]; then
@@ -517,14 +520,16 @@ get_next_config() {
 		export SCRATCH_DEV_NOT_SET=true
 	fi
 
-	echo $SCRATCH_DEV | grep -qE ":|//" > /dev/null 2>&1
-	if [ ! -z "$SCRATCH_DEV" -a ! -b "$SCRATCH_DEV" -a "$?" != "0" -a "$FSTYP" != "overlay" ]; then
-		echo "common/config: Error: \$SCRATCH_DEV ($SCRATCH_DEV) is not a block device or a network filesystem"
-		exit 1
-	elif [ ! -z "$SCRATCH_DEV" -a "$FSTYP" == "overlay" -a ! -d "$SCRATCH_DEV" ]; then
-		echo "common/config: Error: \$SCRATCH_DEV ($SCRATCH_DEV) is not a directory for overlay"
-		exit 1
-	fi
+	if [ "$FSTYP" != "samfs" ]; then
+		echo $SCRATCH_DEV | grep -qE ":|//" > /dev/null 2>&1
+		if [ ! -z "$SCRATCH_DEV" -a ! -b "$SCRATCH_DEV" -a "$?" != "0" -a "$FSTYP" != "overlay" ]; then
+			echo "common/config: Error: \$SCRATCH_DEV ($SCRATCH_DEV) is not a block device or a network filesystem"
+			exit 1
+		elif [ ! -z "$SCRATCH_DEV" -a "$FSTYP" == "overlay" -a ! -d "$SCRATCH_DEV" ]; then
+			echo "common/config: Error: \$SCRATCH_DEV ($SCRATCH_DEV) is not a directory for overlay"
+			exit 1
+		fi
+    fi
 
 	if [ ! -z "$SCRATCH_MNT" -a ! -d "$SCRATCH_MNT" ]; then
 		echo "common/config: Error: \$SCRATCH_MNT ($SCRATCH_MNT) is not a directory"

--- a/common/rc
+++ b/common/rc
@@ -149,6 +149,9 @@ case "$FSTYP" in
 	 ;;
     overlay)
 	 ;;
+    samfs)
+	 [ "$MKFS_SAMFS_PROG" = "" ] && _fatal "mkfs.vsm not found"
+	 ;;
     reiser4)
 	 [ "$MKFS_REISER4_PROG" = "" ] && _fatal "mkfs.reiser4 not found"
 	 ;;
@@ -647,6 +650,9 @@ _test_mkfs()
     overlay)
 	# do nothing for overlay
 	;;
+    samfs)
+	# do nothing for samfs
+	;;
     udf)
         $MKFS_UDF_PROG $MKFS_OPTIONS $* $TEST_DEV > /dev/null
 	;;
@@ -744,6 +750,9 @@ _scratch_mkfs()
 	;;
     f2fs)
         $MKFS_F2FS_PROG $MKFS_OPTIONS $* $SCRATCH_DEV > /dev/null
+	;;
+    samfs)
+        yes | $MKFS_SAMFS_PROG $MKFS_OPTIONS $* $SCRATCH_DEV > /dev/null
 	;;
     *)
 	yes | $MKFS_PROG -t $FSTYP -- $MKFS_OPTIONS $* $SCRATCH_DEV
@@ -1241,6 +1250,12 @@ _require_scratch_nocheck()
 			_notrun "this test requires a valid \$SCRATCH_MNT"
 		fi
 		;;
+	samfs)
+		if [ -z "$SCRATCH_DEV" -o ! -d "$SCRATCH_MNT" ];
+		then
+		    _notrun "this test requires a valid \$SCRATCH_MNT and unique $SCRATCH_DEV"
+		fi
+		;;
 	tmpfs)
 		if [ -z "$SCRATCH_DEV" -o ! -d "$SCRATCH_MNT" ];
 		then
@@ -1321,6 +1336,12 @@ _require_test()
 		fi
 		if [ ! -d "$TEST_DIR" ]; then
 			_notrun "this test requires a valid \$TEST_DIR"
+		fi
+		;;
+	samfs)
+		if [ -z "$TEST_DEV" -o -z "$TEST_DIR" ];
+		then
+		    _notrun "this test requires a valid \$TEST_DIR and \$TEST_DEV"
 		fi
 		;;
 	tmpfs)

--- a/local.config.vsm
+++ b/local.config.vsm
@@ -1,0 +1,13 @@
+# Ideally define at least these 5 to match your environment
+# The first 3 are required.
+# See README for other variables which can be set.
+#
+# Note: SCRATCH_DEV >will< get overwritten!
+#
+# These values correspond to the naming scheme put in place by vsm-config
+
+export FSTYP=samfs
+export TEST_DEV=Qfs3
+export TEST_DIR=/mnt/qfs3
+export SCRATCH_DEV=Qfs4
+export SCRATCH_MNT=/mnt/qfs4


### PR DESCRIPTION
Teach xfstests how to run on a VSM node configured with vsm-config.

To run on such a node:

> git clone git@github.com:/versity/xfstests.git
> cd xfstests
> make
> ln -s local.config.vsm local.config (or just copy it)
> ./check -E samfs_exclude -g quick

Results are in xfstests/results/
